### PR TITLE
store methods, optional serializer, PEP8 file_obj

### DIFF
--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -108,7 +108,8 @@ Or like this::
 
 """
 
-__version__ = '1.6.2'
+__version__ = '1.7'
+
 
 from .workflow import Workflow, PasswordNotFound, KeychainError
 from .workflow import (ICON_ERROR, ICON_WARNING, ICON_NOTE, ICON_INFO,


### PR DESCRIPTION
I have made three alterations to version 1.7:
1. I changed all `open ... as file:` to `open ... as file_obj` to avoid pylint error when redefining built-in
2. Added a new optional parameter to `Workflow()` intialilzation:
   - `serializer` defaults to `pickle` but can be set to anything that supports `load` and `dump` methods
   - `self._serializer` loads or dumps store and cache data in respective methods
   - stored/cached data is saved in file with extension matching `serializer`'s name (`__name__` property)
3. Added `stored_data` and `store_data` methods, which mirror `cached_data` and `cache_data` in functionality.

Thoughts?
