### PR TITLE
Add pre-release support

### DIFF
--- a/workflow/update.py
+++ b/workflow/update.py
@@ -120,6 +120,10 @@ def get_valid_releases(github_slug):
             download_urls.append(url)
 
         # Validate release
+        if release['prerelease']:
+            log.warning(
+                'Invalid release {} : pre-release detected'.format(version))
+            continue
         if not download_urls:
             log.warning(
                 'Invalid release {} : No workflow file'.format(version))


### PR DESCRIPTION
Hi @deanishe,
sometimes I release beta versions of my workflows.
I'd also like to tag them in GitHub just to keep track of everything.

GitHub releases can be flagged as pre-release.
If we simply ignore those in the updater, I could tag beta versions as pre-releases.

What do you think?
