### PR TITLE
Adds a prerelease option in update_settings to enable prerelease updates

### DIFF
--- a/docs/user-manual/magic-arguments.rst
+++ b/docs/user-manual/magic-arguments.rst
@@ -50,6 +50,8 @@ for debugging.
 - ``workflow:update`` — Check for a newer version of the workflow using GitHub releases and install the newer version if one is available.
 - ``workflow:noautoupdate`` — Turn off automatic checks for updates.
 - ``workflow:autoupdate`` — Turn automatic checks for updates on.
+- ``workflow:prereleases`` — Enable updating the workflow to pre-release versions.
+- ``workflow:noprereleases`` — Disable updating the workflow to pre-release versions (default).
 
 The three ``workflow:folding…`` settings allow users to override the diacritic
 folding set by a workflow's author. This may be useful if the author's choice

--- a/docs/user-manual/update.rst
+++ b/docs/user-manual/update.rst
@@ -41,7 +41,10 @@ downloaded and installed via Alfred's default installation mechanism.
 
 .. important::
 
-    Releases marked as ``pre-release`` on GitHub will be ignored.
+    Releases marked as ``pre-release`` on GitHub will be ignored unless the
+    ``workflow:prereleases`` :ref:`magic argument <magic-arguments>` has
+    been enabled or the ``prereleases`` key is set to ``True`` in the
+    ``update_settings`` :class:`dict`.
 
 Configuration
 =============
@@ -73,7 +76,13 @@ installed workflow must also be specified. You can do this in the
         # this key may be omitted
         'version': __version__,
         # Optional number of days between checks for updates
-        'frequency': 7
+        'frequency': 7,
+        # Force checking for pre-release updates
+        # This is only recommended when distributing a pre-release;
+        # otherwise allow users to choose whether they want 
+        # production-ready or pre-release updates with the 
+        # `prereleases` magic argument.
+        'prereleases': '-beta' in __version__
     }, ...)
 
     ...

--- a/docs/user-manual/versioning.rst
+++ b/docs/user-manual/versioning.rst
@@ -94,6 +94,9 @@ the API.
 
 You may also add additional pre-release version info to the end of the version
 number, preceded by a hyphen (``-``), e.g. ``2.0.0-rc.1`` or ``2.0.0-beta``.
+Note that Alfred-Workflow does not use this pre-release version format to
+identify pre-releases; instead the pre-release option on the GitHub release
+editing page must be selected for releases that are not production-ready.
 
 Alfred-Workflow differs from the standard in that you aren't required to
 specify a minor or patch version, i.e. ``1.0`` is fine, as is ``1`` (and both

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -107,7 +107,7 @@ class UpdateTests(unittest.TestCase):
     def test_valid_releases_with_prereleases(self):
         """Update: valid releases with prereleases"""
 
-        releases = update.get_valid_releases(TEST_REPO_SLUG, prerelease=True)
+        releases = update.get_valid_releases(TEST_REPO_SLUG, prereleases=True)
 
         # Right number of valid releases
         self.assertEquals(len(releases), 4)
@@ -129,8 +129,8 @@ class UpdateTests(unittest.TestCase):
         self.assertFalse(update.check_update(TEST_REPO_SLUG, 'v6.0'))
 
         # Up-to-date pre-release versions
-        self.assertFalse(update.check_update(TEST_REPO_SLUG, '7.1-beta', prerelease=True))
-        self.assertFalse(update.check_update(TEST_REPO_SLUG, 'v7.1-beta', prerelease=True))
+        self.assertFalse(update.check_update(TEST_REPO_SLUG, '7.1-beta', prereleases=True))
+        self.assertFalse(update.check_update(TEST_REPO_SLUG, 'v7.1-beta', prereleases=True))
 
         # Old versions
         self.assertTrue(update.check_update(TEST_REPO_SLUG, 'v5.0'))
@@ -152,12 +152,12 @@ class UpdateTests(unittest.TestCase):
     def test_check_update_with_prereleases(self):
         """Update: Check update"""
 
-        self.assertTrue(update.check_update(TEST_REPO_SLUG, RELEASE_CURRENT, prerelease=True))
+        self.assertTrue(update.check_update(TEST_REPO_SLUG, RELEASE_CURRENT, prereleases=True))
 
         update_info = self.wf.cached_data('__workflow_update_status')
         self.assertFalse(update.check_update(TEST_REPO_SLUG,
                                              update_info['version'],
-                                             prerelease=True))
+                                             prereleases=True))
 
     def test_install_update(self):
         """Update: installs update"""
@@ -277,7 +277,7 @@ class UpdateTests(unittest.TestCase):
         wf = Workflow(update_settings={
             'github_slug': 'deanishe/alfred-workflow-dummy',
             'version': 'v2.0',
-            'prerelease': True,
+            'prereleases': True,
             'frequency': 1,
         })
 
@@ -312,7 +312,7 @@ class UpdateTests(unittest.TestCase):
         wf = Workflow(update_settings={
             'github_slug': 'deanishe/alfred-workflow-dummy',
             'version': update_info['version'],
-            'prerelease': True
+            'prereleases': True
         })
 
         wf.run(fake)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -103,6 +103,7 @@ class UpdateTests(unittest.TestCase):
         # Correct latest release
         self.assertEquals(update.Version(releases[0]['version']),
                           update.Version(RELEASE_LATEST))
+        self.assertFalse(releases[0]['prerelease'])
 
     def test_valid_releases_with_prereleases(self):
         """Update: valid releases with prereleases"""
@@ -120,6 +121,7 @@ class UpdateTests(unittest.TestCase):
         # Correct latest release
         self.assertEquals(update.Version(releases[0]['version']),
                           update.Version(RELEASE_LATEST_PRERELEASE))
+        self.assertTrue(releases[0]['prerelease'])
 
     def test_version_formats(self):
         """Update: version formats"""
@@ -141,7 +143,7 @@ class UpdateTests(unittest.TestCase):
         self.assertFalse(update.check_update(TEST_REPO_SLUG, '8.0'))
 
     def test_check_update(self):
-        """Update: Check update with prereleases"""
+        """Update: Check update"""
 
         self.assertTrue(update.check_update(TEST_REPO_SLUG, RELEASE_CURRENT))
 
@@ -150,17 +152,7 @@ class UpdateTests(unittest.TestCase):
                                              update_info['version']))
 
     def test_check_update_with_prereleases(self):
-        """Update: Check update"""
-
-        self.assertTrue(update.check_update(TEST_REPO_SLUG, RELEASE_CURRENT, prereleases=True))
-
-        update_info = self.wf.cached_data('__workflow_update_status')
-        self.assertFalse(update.check_update(TEST_REPO_SLUG,
-                                             update_info['version'],
-                                             prereleases=True))
-
-    def test_check_update_with_prereleases(self):
-        """Update: Check update"""
+        """Update: Check update with prereleases"""
 
         self.assertTrue(update.check_update(TEST_REPO_SLUG, RELEASE_CURRENT, prereleases=True))
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -159,6 +159,16 @@ class UpdateTests(unittest.TestCase):
                                              update_info['version'],
                                              prereleases=True))
 
+    def test_check_update_with_prereleases(self):
+        """Update: Check update"""
+
+        self.assertTrue(update.check_update(TEST_REPO_SLUG, RELEASE_CURRENT, prereleases=True))
+
+        update_info = self.wf.cached_data('__workflow_update_status')
+        self.assertFalse(update.check_update(TEST_REPO_SLUG,
+                                             update_info['version'],
+                                             prereleases=True))
+
     def test_install_update(self):
         """Update: installs update"""
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1431,7 +1431,7 @@ class MagicArgsTests(unittest.TestCase):
                 wf.run(fake)
             self.assertTrue(wf.settings.get('__workflow_autoupdate'))
 
-            wf = Workflow()
+            wf = Workflow(update_settings=update_settings)
             wf.reset()
             c = WorkflowMock(['script', 'workflow:noautoupdate'])
             with c:
@@ -1440,6 +1440,89 @@ class MagicArgsTests(unittest.TestCase):
             self.assertFalse(wf.settings.get('__workflow_autoupdate'))
 
             # del wf.settings['__workflow_autoupdate']
+            wf.reset()
+
+    def test_prereleases(self):
+        """Magic: pre-release updates"""
+
+        update_settings = {
+            'github_slug': 'deanishe/alfred-workflow-dummy',
+            'version': 'v2.0',
+            'frequency': 1,
+        }
+
+        def fake(wf):
+            return
+
+        with InfoPlist():
+            wf = Workflow(update_settings=update_settings)
+            c = WorkflowMock(['script', 'workflow:prereleases'])
+            with c:
+                wf.args
+                wf.run(fake)
+            self.assertTrue(wf.settings.get('__workflow_prereleases'))
+
+            wf = Workflow(update_settings=update_settings)
+            wf.reset()
+            c = WorkflowMock(['script', 'workflow:noprereleases'])
+            with c:
+                wf.args
+                wf.run(fake)
+            self.assertFalse(wf.settings.get('__workflow_prereleases'))
+
+            wf.reset()
+
+    def test_update_settings_override_magic_prereleases(self):
+        """Magic: pre-release updates can be overridden by `True` value for `prereleases` key in `update_settings`"""
+
+        update_settings = {
+            'github_slug': 'deanishe/alfred-workflow-dummy',
+            'version': 'v2.0',
+            'frequency': 1,
+            'prereleases': False,
+        }
+
+        def fake(wf):
+            return
+
+        # Normal behavior
+        with InfoPlist():
+            wf = Workflow(update_settings=update_settings)
+            c = WorkflowMock(['script', 'workflow:prereleases'])
+            with c:
+                wf.args
+                wf.run(fake)
+            self.assertTrue(wf.prereleases)
+
+            wf = Workflow(update_settings=update_settings)
+            wf.reset()
+            c = WorkflowMock(['script', 'workflow:noprereleases'])
+            with c:
+                wf.args
+                wf.run(fake)
+            self.assertFalse(wf.prereleases)
+
+            wf.reset()
+
+        update_settings['prereleases'] = True
+
+        # Pre-release enabled regardless of preference
+        with InfoPlist():
+            wf = Workflow(update_settings=update_settings)
+            c = WorkflowMock(['script', 'workflow:prereleases'])
+            with c:
+                wf.args
+                wf.run(fake)
+            self.assertTrue(wf.prereleases)
+
+            wf = Workflow(update_settings=update_settings)
+            wf.reset()
+            c = WorkflowMock(['script', 'workflow:noprereleases'])
+            with c:
+                wf.args
+                wf.run(fake)
+            self.assertTrue(wf.prereleases)
+
             wf.reset()
 
     def test_update(self):
@@ -1478,8 +1561,8 @@ class MagicArgsTests(unittest.TestCase):
                 wf.run(fake)
                 wf.args
 
-        # Update command wasn't called
-        self.assertEqual(c.cmd, ())
+            # Update command wasn't called
+            self.assertEqual(c.cmd, ())
 
     def test_update_turned_off(self):
         """Magic: updates turned off"""

--- a/workflow/update.py
+++ b/workflow/update.py
@@ -213,9 +213,10 @@ def get_valid_releases(github_slug, prereleases=False):
     """Return list of all valid releases
 
     :param github_slug: ``username/repo`` for workflow's GitHub repo
-    :param prereleases: Whether to download pre-release updates.
+    :param prereleases: Whether to include pre-releases.
     :returns: list of dicts. Each :class:`dict` has the form
-        ``{'version': '1.1', 'download_url': 'http://github.com/...'}``
+        ``{'version': '1.1', 'download_url': 'http://github.com/...',
+        'prerelease': False }``
 
 
     A valid release is one that contains one ``.alfredworkflow`` file.
@@ -262,7 +263,11 @@ def get_valid_releases(github_slug, prereleases=False):
             continue
 
         wf().logger.debug('Release `{0}` : {1}'.format(version, url))
-        releases.append({'version': version, 'download_url': download_urls[0]})
+        releases.append({
+            'version': version,
+            'download_url': download_urls[0],
+            'prerelease': release['prerelease']
+        })
 
     return releases
 
@@ -273,7 +278,7 @@ def check_update(github_slug, current_version, prereleases=False):
     :param github_slug: ``username/repo`` for workflow's GitHub repo
     :param current_version: the currently installed version of the
         workflow. :ref:`Semantic versioning <semver>` is required.
-    :param prereleases: Whether to download pre-release updates.
+    :param prereleases: Whether to include pre-releases.
     :type current_version: ``unicode``
     :returns: ``True`` if an update is available, else ``False``
 

--- a/workflow/update.py
+++ b/workflow/update.py
@@ -348,18 +348,24 @@ if __name__ == '__main__':  # pragma: nocover
     import sys
 
     def show_help():
-        print('Usage : update.py (check|install) github_slug version prereleases')
+        print('Usage : update.py (check|install) github_slug version [--prereleases]')
         sys.exit(1)
 
-    if len(sys.argv) != 5:
+    argv = sys.argv[:]
+    prereleases = '--prereleases' in argv
+
+    if prereleases:
+        argv.remove('--prereleases')
+
+    if len(argv) != 4:
         show_help()
 
-    action, github_slug, version, prereleases = sys.argv[1:]
+    action, github_slug, version = argv[1:]
 
     if action not in ('check', 'install'):
         show_help()
 
     if action == 'check':
-        check_update(github_slug, version, prereleases != '0')
+        check_update(github_slug, version, prereleases)
     elif action == 'install':
         install_update(github_slug, version)

--- a/workflow/update.py
+++ b/workflow/update.py
@@ -209,11 +209,11 @@ def build_api_url(slug):
     return RELEASES_BASE.format(slug)
 
 
-def get_valid_releases(github_slug, prerelease=False):
+def get_valid_releases(github_slug, prereleases=False):
     """Return list of all valid releases
 
     :param github_slug: ``username/repo`` for workflow's GitHub repo
-    :param prerelease: Whether to download prerelease updates.
+    :param prereleases: Whether to download pre-release updates.
     :returns: list of dicts. Each :class:`dict` has the form
         ``{'version': '1.1', 'download_url': 'http://github.com/...'}``
 
@@ -248,7 +248,7 @@ def get_valid_releases(github_slug, prerelease=False):
             download_urls.append(url)
 
         # Validate release
-        if release['prerelease'] and not prerelease:
+        if release['prerelease'] and not prereleases:
             wf().logger.warning(
                 'Invalid release {0} : pre-release detected'.format(version))
             continue
@@ -267,13 +267,13 @@ def get_valid_releases(github_slug, prerelease=False):
     return releases
 
 
-def check_update(github_slug, current_version, prerelease=False):
+def check_update(github_slug, current_version, prereleases=False):
     """Check whether a newer release is available on GitHub
 
     :param github_slug: ``username/repo`` for workflow's GitHub repo
     :param current_version: the currently installed version of the
         workflow. :ref:`Semantic versioning <semver>` is required.
-    :param prerelease: Whether to download prerelease updates.
+    :param prereleases: Whether to download pre-release updates.
     :type current_version: ``unicode``
     :returns: ``True`` if an update is available, else ``False``
 
@@ -282,7 +282,7 @@ def check_update(github_slug, current_version, prerelease=False):
 
     """
 
-    releases = get_valid_releases(github_slug, prerelease)
+    releases = get_valid_releases(github_slug, prereleases)
 
     wf().logger.info('{0} releases for {1}'.format(len(releases),
                                                     github_slug))
@@ -348,18 +348,18 @@ if __name__ == '__main__':  # pragma: nocover
     import sys
 
     def show_help():
-        print('Usage : update.py (check|install) github_slug version prerelease')
+        print('Usage : update.py (check|install) github_slug version prereleases')
         sys.exit(1)
 
     if len(sys.argv) != 5:
         show_help()
 
-    action, github_slug, version, prerelease = sys.argv[1:]
+    action, github_slug, version, prereleases = sys.argv[1:]
 
     if action not in ('check', 'install'):
         show_help()
 
     if action == 'check':
-        check_update(github_slug, version, prerelease != '0')
+        check_update(github_slug, version, prereleases != '0')
     elif action == 'install':
         install_update(github_slug, version)

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -1030,8 +1030,9 @@ class Workflow(object):
             This must be a :class:`dict` that contains ``github_slug`` and
             ``version`` keys. ``github_slug`` is of the form ``username/repo``
             and ``version`` **must** correspond to the tag of a release. The
-            boolean ``prerelease`` key is optional; by default prereleases are
-            ignored.
+            boolean ``prereleases`` key is optional and if ``True`` will
+            override the :ref:`magic argument <magic-arguments>` preference.
+            This is only recommended when the installed workflow is a pre-release.
             See :ref:`updates` for more information.
         :type update_settings: :class:`dict`
         :param input_encoding: encoding of command line arguments
@@ -2383,7 +2384,7 @@ class Workflow(object):
                 '__workflow_update_status', frequency * 86400)):
 
             github_slug = self._update_settings['github_slug']
-            prerelease = str(int(bool(self._update_settings.get('prerelease'))))
+            prereleases = str(int(bool(self._update_settings.get('prereleases'))))
             # version = self._update_settings['version']
             version = str(self.version)
 
@@ -2394,7 +2395,7 @@ class Workflow(object):
                                          b'update.py')
 
             cmd = ['/usr/bin/python', update_script, 'check', github_slug,
-                   version, prerelease]
+                   version, prereleases]
 
             self.logger.info('Checking for update ...')
 
@@ -2419,11 +2420,11 @@ class Workflow(object):
         import update
 
         github_slug = self._update_settings['github_slug']
-        prerelease = str(int(bool(self._update_settings.get('prerelease'))))
+        prereleases = str(int(bool(self._update_settings.get('prereleases'))))
         # version = self._update_settings['version']
         version = str(self.version)
 
-        if not update.check_update(github_slug, version, prerelease):
+        if not update.check_update(github_slug, version, prereleases):
             return False
 
         from background import run_in_background
@@ -2433,7 +2434,7 @@ class Workflow(object):
                                      b'update.py')
 
         cmd = ['/usr/bin/python', update_script, 'install', github_slug,
-               version, prerelease]
+               version, prereleases]
 
         self.logger.debug('Downloading update ...')
         run_in_background('__workflow_update_install', cmd)

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -1029,7 +1029,9 @@ class Workflow(object):
         :param update_settings: settings for updating your workflow from GitHub.
             This must be a :class:`dict` that contains ``github_slug`` and
             ``version`` keys. ``github_slug`` is of the form ``username/repo``
-            and ``version`` **must** correspond to the tag of a release.
+            and ``version`` **must** correspond to the tag of a release. The
+            boolean ``prerelease`` key is optional; by default prereleases are
+            ignored.
             See :ref:`updates` for more information.
         :type update_settings: :class:`dict`
         :param input_encoding: encoding of command line arguments
@@ -2381,6 +2383,7 @@ class Workflow(object):
                 '__workflow_update_status', frequency * 86400)):
 
             github_slug = self._update_settings['github_slug']
+            prerelease = str(int(bool(self._update_settings.get('prerelease'))))
             # version = self._update_settings['version']
             version = str(self.version)
 
@@ -2391,7 +2394,7 @@ class Workflow(object):
                                          b'update.py')
 
             cmd = ['/usr/bin/python', update_script, 'check', github_slug,
-                   version]
+                   version, prerelease]
 
             self.logger.info('Checking for update ...')
 
@@ -2416,10 +2419,11 @@ class Workflow(object):
         import update
 
         github_slug = self._update_settings['github_slug']
+        prerelease = int(bool(self._update_settings.get('prerelease')))
         # version = self._update_settings['version']
         version = str(self.version)
 
-        if not update.check_update(github_slug, version):
+        if not update.check_update(github_slug, version, prerelease):
             return False
 
         from background import run_in_background
@@ -2429,7 +2433,7 @@ class Workflow(object):
                                      b'update.py')
 
         cmd = ['/usr/bin/python', update_script, 'install', github_slug,
-               version]
+               version, prerelease]
 
         self.logger.debug('Downloading update ...')
         run_in_background('__workflow_update_install', cmd)

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -2419,7 +2419,7 @@ class Workflow(object):
         import update
 
         github_slug = self._update_settings['github_slug']
-        prerelease = int(bool(self._update_settings.get('prerelease')))
+        prerelease = str(int(bool(self._update_settings.get('prerelease'))))
         # version = self._update_settings['version']
         version = str(self.version)
 

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -2356,6 +2356,21 @@ class Workflow(object):
 
         return update_data['available']
 
+    @property
+    def prereleases(self):
+        """Should the workflow update to a newer pre-release version if
+        available?
+
+        :returns: ``True`` if pre-releases are enabled with the :ref:`magic
+        argument <magic-arguments>` or the ``update_settings`` dict, else
+        ``False``
+
+        """
+        if self._update_settings.get('prereleases'):
+            return True
+
+        return self.settings.get('__workflow_prereleases') or False
+
     def check_update(self, force=False):
         """Call update script if it's time to check for a new release
 
@@ -2384,7 +2399,7 @@ class Workflow(object):
                 '__workflow_update_status', frequency * 86400)):
 
             github_slug = self._update_settings['github_slug']
-            prereleases = str(int(bool(self._update_settings.get('prereleases'))))
+            prereleases = str(int(self.prereleases))
             # version = self._update_settings['version']
             version = str(self.version)
 
@@ -2420,7 +2435,7 @@ class Workflow(object):
         import update
 
         github_slug = self._update_settings['github_slug']
-        prereleases = str(int(bool(self._update_settings.get('prereleases'))))
+        prereleases = str(int(self.prereleases))
         # version = self._update_settings['version']
         version = str(self.version)
 
@@ -2606,6 +2621,14 @@ class Workflow(object):
             self.settings['__workflow_autoupdate'] = False
             return 'Auto update turned off'
 
+        def prereleases_on():
+            self.settings['__workflow_prereleases'] = True
+            return 'Prerelease updates turned on'
+
+        def prereleases_off():
+            self.settings['__workflow_prereleases'] = False
+            return 'Prerelease updates turned off'
+
         def do_update():
             if self.start_update():
                 return 'Downloading and installing update ...'
@@ -2614,6 +2637,8 @@ class Workflow(object):
 
         self.magic_arguments['autoupdate'] = update_on
         self.magic_arguments['noautoupdate'] = update_off
+        self.magic_arguments['prereleases'] = prereleases_on
+        self.magic_arguments['noprereleases'] = prereleases_off
         self.magic_arguments['update'] = do_update
 
         # Help

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -2399,7 +2399,6 @@ class Workflow(object):
                 '__workflow_update_status', frequency * 86400)):
 
             github_slug = self._update_settings['github_slug']
-            prereleases = str(int(self.prereleases))
             # version = self._update_settings['version']
             version = str(self.version)
 
@@ -2410,7 +2409,10 @@ class Workflow(object):
                                          b'update.py')
 
             cmd = ['/usr/bin/python', update_script, 'check', github_slug,
-                   version, prereleases]
+                   version]
+
+            if self.prereleases:
+                cmd.append('--prereleases')
 
             self.logger.info('Checking for update ...')
 
@@ -2435,11 +2437,10 @@ class Workflow(object):
         import update
 
         github_slug = self._update_settings['github_slug']
-        prereleases = str(int(self.prereleases))
         # version = self._update_settings['version']
         version = str(self.version)
 
-        if not update.check_update(github_slug, version, prereleases):
+        if not update.check_update(github_slug, version, self.prereleases):
             return False
 
         from background import run_in_background
@@ -2449,7 +2450,10 @@ class Workflow(object):
                                      b'update.py')
 
         cmd = ['/usr/bin/python', update_script, 'install', github_slug,
-               version, prereleases]
+               version]
+
+        if self.prereleases:
+            cmd.append('--prereleases')
 
         self.logger.debug('Downloading update ...')
         run_in_background('__workflow_update_install', cmd)


### PR DESCRIPTION
This pull request adds a `prerelease` option to the `update_settings` dict which will allow users of my workflow to subscribe to a pre-release update channel. It was great to see that the version matching already handles version suffixes, so updating 0.6.0-alpha.1 to 0.6.0-alpha.2 worked as expected.

I did not add a note in the documentation about the Alfred-Workflow version at which the `prerelease` option was added. The only backwards compatibility concern is if anyone ran update.py manually, since it now requires 5 rather than 4 arguments.