### PR TITLE
Support POST requests without data in web.py

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -184,6 +184,13 @@ class WebTests(unittest.TestCase):
             self.assert_(data['json'][key] == self.data[key])
         return
 
+    def test_post_without_data(self):
+        """POST request without data"""
+        url = BASE_URL + 'post'
+        r = web.post(url)
+        self.assert_(r.status_code == 200)
+        r.raise_for_status()
+
     def test_timeout(self):
         """Request times out"""
         url = BASE_URL + 'delay/10'

--- a/workflow/web.py
+++ b/workflow/web.py
@@ -472,7 +472,6 @@ def request(method, url, params=None, data=None, headers=None, cookies=None,
     """
 
     # TODO: cookies
-    # TODO: any way to force GET or POST?
     socket.setdefaulttimeout(timeout)
 
     # Default handlers
@@ -507,6 +506,10 @@ def request(method, url, params=None, data=None, headers=None, cookies=None,
         encodings.append('gzip')
 
     headers['accept-encoding'] = ', '.join(encodings)
+
+    # Force a POST by providing an empty data string
+    if method == 'POST' and not data:
+        data = ''
 
     if files:
         if not data:


### PR DESCRIPTION
The urllib2 documentation explicitly states that the HTTP request
will be a POST instead of a GET when the data parameter is provided.

If the method parameter specifies POST we now force urllib2 to use
the correct method by setting the data parameter to an empty string.