### PR TITLE
change web.Response to return empty values instead of excepting

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,18 @@ The main entry point for unit testing is the `run-tests.sh` script in the root
 directory. This will fail *if code coverage is < 100%*. Travis-CI also uses
 this script. Add `# pragma: no cover` with care.
 
+#### Getting up and running
+
+This project uses [tox](https://testrun.org/tox/latest/) and
+[nose](https://nose.readthedocs.org/en/latest/) for running tests. Tox will
+install all the dependencies for you, if you install it first:
+```sh
+sudo easy_install tox
+```
+And then run `tox` in the root directory of this project. If you choose to use
+`run_tests.sh` directly, you'll need to manually install the dependencies listed
+in `tox.ini` (like yanc).
+
 
 ### Contributors ###
 


### PR DESCRIPTION
Hi!

I was using this awesome project for some of my own alfred workflows, and while debugging I noticed that when things like HTTP Basic Auth fail, the `self.raw` property on `web.Response` ends up as `None`. This causes things like `self.content` and `self.text` to raise an exception, which was very confusing to me.

I've changed this in my PR so that these methods return empty strings in those cases. I've also added a tiny bit to the README about running unit tests (it wasn't clear to me, because `/.run-tests.sh` failed because of `yanc` missing. Looks like using `tox` takes care of that, but let me know if that's wrong.

Thanks!