### PR TITLE
Adds a prereleases magic argument and update_settings option to enable prerelease updates

### DIFF
--- a/docs/user-manual/magic-arguments.rst
+++ b/docs/user-manual/magic-arguments.rst
@@ -54,6 +54,8 @@ for debugging.
 - ``workflow:update`` — Check for a newer version of the workflow using GitHub releases and install the newer version if one is available.
 - ``workflow:noautoupdate`` — Turn off automatic checks for updates.
 - ``workflow:autoupdate`` — Turn automatic checks for updates on.
+- ``workflow:prereleases`` — Enable updating the workflow to pre-release versions.
+- ``workflow:noprereleases`` — Disable updating the workflow to pre-release versions (default).
 
 The three ``workflow:folding…`` settings allow users to override the diacritic
 folding set by a workflow's author. This may be useful if the author's choice

--- a/docs/user-manual/update.rst
+++ b/docs/user-manual/update.rst
@@ -45,7 +45,10 @@ downloaded and installed via Alfred's default installation mechanism.
 
 .. important::
 
-    Releases marked as ``pre-release`` on GitHub will be ignored.
+    Releases marked as ``pre-release`` on GitHub will be ignored unless the
+    ``workflow:prereleases`` :ref:`magic argument <magic-arguments>` has
+    been enabled or the ``prereleases`` key is set to ``True`` in the
+    ``update_settings`` :class:`dict`.
 
 Configuration
 =============
@@ -77,7 +80,13 @@ installed workflow must also be specified. You can do this in the
         # this key may be omitted
         'version': __version__,
         # Optional number of days between checks for updates
-        'frequency': 7
+        'frequency': 7,
+        # Force checking for pre-release updates
+        # This is only recommended when distributing a pre-release;
+        # otherwise allow users to choose whether they want 
+        # production-ready or pre-release updates with the 
+        # `prereleases` magic argument.
+        'prereleases': '-beta' in __version__
     }, ...)
 
     ...

--- a/docs/user-manual/versioning.rst
+++ b/docs/user-manual/versioning.rst
@@ -98,6 +98,9 @@ the API.
 
 You may also add additional pre-release version info to the end of the version
 number, preceded by a hyphen (``-``), e.g. ``2.0.0-rc.1`` or ``2.0.0-beta``.
+Note that Alfred-Workflow does not use this pre-release version format to
+identify pre-releases; instead the pre-release option on the GitHub release
+editing page must be selected for releases that are not production-ready.
 
 Alfred-Workflow differs from the standard in that you aren't required to
 specify a minor or patch version, i.e. ``1.0`` is fine, as is ``1`` (and both

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1409,6 +1409,42 @@ class MagicArgsTests(unittest.TestCase):
                 wf.args
             self.assertFalse(wf.settings.get('__workflow_diacritic_folding'))
 
+    def test_prereleases(self):
+        """Magic: prereleases"""
+        with InfoPlist():
+            wf = Workflow()
+
+            c = WorkflowMock(['script', 'workflow:prereleases'])
+            with c:
+                wf.args
+            self.assertTrue(wf.settings.get('__workflow_prereleases'))
+            self.assertTrue(wf.prereleases)
+
+            wf = Workflow()
+            c = WorkflowMock(['script', 'workflow:noprereleases'])
+            with c:
+                wf.args
+            self.assertFalse(wf.settings.get('__workflow_prereleases'))
+            self.assertFalse(wf.prereleases)
+
+    def test_update_settings_override_magic_prereleases(self):
+        """Magic: pre-release updates can be overridden by `True` value for `prereleases` key in `update_settings`"""
+        with InfoPlist():
+            d = {'prereleases': True}
+            wf = Workflow(update_settings=d)
+
+            c = WorkflowMock(['script', 'workflow:prereleases'])
+            with c:
+                wf.args
+            self.assertTrue(wf.settings.get('__workflow_prereleases'))
+            self.assertTrue(wf.prereleases)
+
+            wf = Workflow(update_settings=d)
+            c = WorkflowMock(['script', 'workflow:noprereleases'])
+            with c:
+                wf.args
+            self.assertFalse(wf.settings.get('__workflow_prereleases'))
+            self.assertTrue(wf.prereleases)
 
 class AtomicWriterTests(unittest.TestCase):
     """Tests for atomic writer"""

--- a/tests/test_workflow_update.py
+++ b/tests/test_workflow_update.py
@@ -102,6 +102,37 @@ def test_update(httpserver):
             assert c.cmd == ()
 
 
+def test_update_with_prereleases(httpserver):
+    """Auto-update installs update with pre-releases enabled"""
+
+    def fake(wf):
+        return
+
+    # Mock subprocess.call etc. so the script doesn't try to
+    # update the workflow in Alfred
+    with fakeresponse(httpserver, DATA_JSON, HTTP_HEADERS_JSON):
+        update_settings = UPDATE_SETTINGS.copy()
+        update_settings['prereleases'] = True
+        with ctx(['workflow:update'], update_settings, clear=False) as (wf, c):
+            wf.run(fake)
+            wf.args
+
+            print('Magic update command : {0!r}'.format(c.cmd))
+
+            assert c.cmd[0] == '/usr/bin/python'
+            assert c.cmd[2] == '__workflow_update_install'
+
+        update_settings = UPDATE_SETTINGS.copy()
+        update_settings['version'] = 'v7.1-beta'
+        update_settings['prereleases'] = True
+        with ctx(['workflow:update'], update_settings) as (wf, c):
+            wf.run(fake)
+            wf.args
+
+            # Update command wasn't called
+            assert c.cmd == ()
+
+
 def test_update_available(httpserver):
     """update_available property works"""
     slug = UPDATE_SETTINGS['github_slug']

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -1039,7 +1039,10 @@ class Workflow(object):
         :param update_settings: settings for updating your workflow from GitHub.
             This must be a :class:`dict` that contains ``github_slug`` and
             ``version`` keys. ``github_slug`` is of the form ``username/repo``
-            and ``version`` **must** correspond to the tag of a release.
+            and ``version`` **must** correspond to the tag of a release. The
+            boolean ``prereleases`` key is optional and if ``True`` will
+            override the :ref:`magic argument <magic-arguments>` preference.
+            This is only recommended when the installed workflow is a pre-release.
             See :ref:`updates` for more information.
         :type update_settings: :class:`dict`
         :param input_encoding: encoding of command line arguments
@@ -2363,6 +2366,23 @@ class Workflow(object):
 
         return update_data['available']
 
+    @property
+    def prereleases(self):
+        """Should the workflow update to a newer pre-release version if
+        available?
+
+        .. versionadded:: 1.16
+
+        :returns: ``True`` if pre-releases are enabled with the :ref:`magic
+        argument <magic-arguments>` or the ``update_settings`` dict, else
+        ``False``
+
+        """
+        if self._update_settings.get('prereleases'):
+            return True
+
+        return self.settings.get('__workflow_prereleases') or False
+
     def check_update(self, force=False):
         """Call update script if it's time to check for a new release
 
@@ -2403,6 +2423,9 @@ class Workflow(object):
             cmd = ['/usr/bin/python', update_script, 'check', github_slug,
                    version]
 
+            if self.prereleases:
+                cmd.append('--prereleases')
+
             self.logger.info('Checking for update ...')
 
             run_in_background('__workflow_update_check', cmd)
@@ -2429,7 +2452,7 @@ class Workflow(object):
         # version = self._update_settings['version']
         version = str(self.version)
 
-        if not update.check_update(github_slug, version):
+        if not update.check_update(github_slug, version, self.prereleases):
             return False
 
         from background import run_in_background
@@ -2440,6 +2463,9 @@ class Workflow(object):
 
         cmd = ['/usr/bin/python', update_script, 'install', github_slug,
                version]
+
+        if self.prereleases:
+            cmd.append('--prereleases')
 
         self.logger.debug('Downloading update ...')
         run_in_background('__workflow_update_install', cmd)
@@ -2611,6 +2637,14 @@ class Workflow(object):
             self.settings['__workflow_autoupdate'] = False
             return 'Auto update turned off'
 
+        def prereleases_on():
+            self.settings['__workflow_prereleases'] = True
+            return 'Prerelease updates turned on'
+
+        def prereleases_off():
+            self.settings['__workflow_prereleases'] = False
+            return 'Prerelease updates turned off'
+
         def do_update():
             if self.start_update():
                 return 'Downloading and installing update ...'
@@ -2619,6 +2653,8 @@ class Workflow(object):
 
         self.magic_arguments['autoupdate'] = update_on
         self.magic_arguments['noautoupdate'] = update_off
+        self.magic_arguments['prereleases'] = prereleases_on
+        self.magic_arguments['noprereleases'] = prereleases_off
         self.magic_arguments['update'] = do_update
 
         # Help


### PR DESCRIPTION
This pull request adds a `prereleases` magic argument and optional override in the `update_settings` dict which will allow users of a workflow to subscribe to a pre-release update channel. Tests are rewritten for py.test and changes are rebased on develop.

See #73 for discussion.

I am not confident on the tests for the workflow:update command and so left them in a separate commit for now. I ended up initializing the contexts with `clear=False` because the second test tried to run `__workflow_update_check` in the background which caused `assert c.cmd == ()` to fail. I think that this is still a valid way to test since the `update` magic arg avoids the update info cache and does a clean `update.check_update`.

Whereas `test_update` asserts `wf.update_available is False` after creating that initial context, `wf.update_available` was `True` in the `test_update_with_prereleases`. Is the purpose of that initial run to get the background update check out of the way? I suspect something is leaking between these two tests, especially since `assert c.cmd == ()` worked for `test_update` even without `clear=False`. 
```python
def test_update(httpserver):
    with ctx() as (wf, c):
        wf.run(fake)
        assert wf.update_available is False
    [...]

def test_update_with_prereleases(httpserver):
    with ctx() as (wf, c):
        wf.run(fake)
        # wf.update_available is actually True here
    [...]
```