### PR TITLE
Make saving of settings.json uninterruptible to avoid hanging lockfiles.

### DIFF
--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -989,6 +989,7 @@ class Settings(dict):
         self._original = deepcopy(d)
         self._nosave = False
 
+    @uninterruptible
     def save(self):
         """Save settings to JSON file specified in ``self._filepath``
 


### PR DESCRIPTION
I received [a half dozen reports](https://github.com/idpaterson/alfred-wunderlist-workflow/issues/90) of my workflow's script filter hanging after using the workflow a few times. It turned out to be caused by the *Terminate previous script* behavior in Alfred, a likely suspect for which you have already guarded `store_data`. The lockfile acquired for settings.json can remain if the process is killed while writing the JSON file. This leaves the next process to hang while attempting to acquiring the lock.

In this pull request I decorated `Settings.save` with `@uninterruptible` to ensure that the script is not killed until the settings file has been written and the lockfile unlinked. 

This can most easily be tested by resetting the datadir then intentionally killing the process after acquiring the lock:
```python
with LockFile(self._filepath):
    os.kill(os.getpid(), signal.SIGTERM)
    with atomic_writer(self._filepath, 'wb') as file_obj:
        json.dump(data, file_obj, sort_keys=True, indent=2,
                  encoding='utf-8')
```

Previously this resulted in a settings.json.lock file remaining in the datadir, but as expected with the uninterruptible flag the save completes before the process is killed.