### PR TITLE
Use 'communicate()' to avoid deadlocks in '_call_security' #81

### DIFF
--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -65,7 +65,7 @@ class BackgroundTests(unittest.TestCase):
         self.assertTrue(os.path.exists('info.plist'))
         cmd = ['sleep', '1']
         run_in_background('test', cmd)
-        sleep(0.5)
+        sleep(0.6)
         self.assertTrue(is_running('test'))
         self.assertTrue(os.path.exists(self._pidfile('test')))
         self.assertEqual(run_in_background('test', cmd), None)

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -2922,13 +2922,13 @@ class Workflow(object):
         cmd = ['security', action, '-s', service, '-a', account] + list(args)
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT)
-        retcode, output = p.wait(), p.stdout.read().strip().decode('utf-8')
-        if retcode == 44:  # password does not exist
+        stdout, _ = p.communicate()
+        if p.returncode == 44:  # password does not exist
             raise PasswordNotFound()
-        elif retcode == 45:  # password already exists
+        elif p.returncode == 45:  # password already exists
             raise PasswordExists()
-        elif retcode > 0:
-            err = KeychainError('Unknown Keychain error : %s' % output)
-            err.retcode = retcode
+        elif p.returncode > 0:
+            err = KeychainError('Unknown Keychain error : %s' % stdout)
+            err.retcode = p.returncode
             raise err
-        return output
+        return stdout.strip().decode('utf-8')


### PR DESCRIPTION
Following up on #81:

This PR fixes a deadlock problem caused by `p.wait()`. Instead, it is recommended to use `communicate()`:

> Warning This will deadlock when using stdout=PIPE and/or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. Use communicate() to avoid that.

https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait