### PR TITLE
Import cPickle from six

### DIFF
--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -19,7 +19,7 @@ from __future__ import print_function, unicode_literals
 
 import binascii
 from contextlib import contextmanager
-import cPickle
+from six.moves import cPickle
 from copy import deepcopy
 import errno
 import json


### PR DESCRIPTION
Directly import cpickle won't work on my env,
this patch make import cPickle from six to make it
compatible with python3