### PR TITLE
remove print() from web.py

### DIFF
--- a/workflow/web.py
+++ b/workflow/web.py
@@ -433,7 +433,6 @@ class Response(object):
                               self.content)
                 if m:
                     encoding = m.group(1)
-                    print('sniffed HTML encoding=%r' % encoding)
 
             elif ((self.mimetype.startswith('application/') or
                    self.mimetype.startswith('text/')) and


### PR DESCRIPTION
cause "[input.scriptfilter] JSON error: JSON text did not start with array or object and option to allow fragments not set. in JSON: sniffed HTML encoding='utf-8'" error for me