### PR TITLE
Allow plain text exceptions for Alfred notification outputs

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -834,6 +834,50 @@ class WorkflowTests(unittest.TestCase):
         ret = self.wf.run(cb)
         self.assertEqual(ret, 1)
 
+    def test_run_fails_with_xml_output(self):
+        """Run fails with XML output"""
+        error_text = 'Have an error'
+        def cb(wf):
+            self.assertEqual(wf, self.wf)
+            raise ValueError(error_text)
+        # named after bundleid
+        self.wf = Workflow()
+        self.wf.bundleid
+
+        stdout = sys.stdout
+        sio = StringIO()
+        sys.stdout = sio
+        ret = self.wf.run(cb)
+        sys.stdout = stdout
+        output = sio.getvalue()
+        sio.close()
+
+        self.assertEqual(ret, 1)
+        self.assertTrue(error_text in output)
+        self.assertTrue('<?xml' in output)
+
+    def test_run_fails_with_plain_text_output(self):
+        """Run fails with plain text output"""
+        error_text = 'Have an error'
+        def cb(wf):
+            self.assertEqual(wf, self.wf)
+            raise ValueError(error_text)
+        # named after bundleid
+        self.wf = Workflow()
+        self.wf.bundleid
+
+        stdout = sys.stdout
+        sio = StringIO()
+        sys.stdout = sio
+        ret = self.wf.run(cb, plaintext_exceptions=True)
+        sys.stdout = stdout
+        output = sio.getvalue()
+        sio.close()
+
+        self.assertEqual(ret, 1)
+        self.assertTrue(error_text in output)
+        self.assertTrue('<?xml' not in output)
+
     def test_run_fails_borked_settings(self):
         """Run fails with borked settings.json"""
 

--- a/tests/test_workflow3.py
+++ b/tests/test_workflow3.py
@@ -194,3 +194,47 @@ def test_default_directories(info3):
     wf3 = Workflow3()
     assert 'Alfred 3' in wf3.datadir
     assert 'Alfred-3' in wf3.cachedir
+
+
+def test_run_fails_with_json_output():
+    """Run fails with JSON output"""
+    error_text = 'Have an error'
+    def cb(wf):
+        raise ValueError(error_text)
+    # named after bundleid
+    wf = Workflow3()
+    wf.bundleid
+
+    stdout = sys.stdout
+    sio = StringIO()
+    sys.stdout = sio
+    ret = wf.run(cb)
+    sys.stdout = stdout
+    output = sio.getvalue()
+    sio.close()
+
+    assert ret == 1
+    assert error_text in output
+    assert '{' in output
+
+
+def test_run_fails_with_plain_text_output():
+    """Run fails with plain text output"""
+    error_text = 'Have an error'
+    def cb(wf):
+        raise ValueError(error_text)
+    # named after bundleid
+    wf = Workflow3()
+    wf.bundleid
+
+    stdout = sys.stdout
+    sio = StringIO()
+    sys.stdout = sio
+    ret = wf.run(cb, plaintext_exceptions=True)
+    sys.stdout = stdout
+    output = sio.getvalue()
+    sio.close()
+
+    assert ret == 1
+    assert error_text in output
+    assert '{' not in output


### PR DESCRIPTION
Adds an `exception_format` arg to `Workflow.run` to allow plain text exceptions for notification outputs with tests to verify the original and new format. 

This morning [a few users reported XML errors](https://github.com/idpaterson/alfred-wunderlist-workflow/issues/136) showing up in notifications that normally say something like "The task has been added." The API used by my workflow was tossing *503 Service Unavailable* errors, exceptions for which were caught by alfred-workflow. However, the errors were being formatted for a script filter response when the code was actually running in a script action that provides plain text to a notification output, so users saw a notification with text `<?xml version="1.0" encoding="utf-8"?>`.

This is a backwards-compatible, quick fix type of change. There may be a more appropriate or even automatic way to produce the correct output for the current context but for now this seems to be the easiest place to modify this behavior. 

In my case the exact same code runs in a script filter and in a script action. Both are triggered by a bash script in Alfred, the latter providing a `--commit` argument to the python script to signify that the user selected something that can be actioned. So, it is more convenient for me to specify this flag at the `wf.run()` call where `wf.args` is available than as a config setting when constructing the workflow.

After this change exceptions can be configured to appear in plain text when necessary:
![error notification](https://cloud.githubusercontent.com/assets/507058/18711219/e2f9f2f6-7fd6-11e6-8572-eb9266f50dee.png)