### PR TITLE
Avoids hung subprocess on macOS 10.12.4 when running a background task

### DIFF
--- a/workflow/background.py
+++ b/workflow/background.py
@@ -16,6 +16,7 @@ import sys
 import os
 import subprocess
 import pickle
+from time import sleep
 
 from workflow import Workflow
 
@@ -125,6 +126,7 @@ def _background(stdin='/dev/null', stdout='/dev/null',
     try:
         pid = os.fork()
         if pid > 0:
+            sleep(0.25)  # Avoid hung subprocess on macOS 10.12.4
             sys.exit(0)  # Exit second parent.
     except OSError as e:
         wf().logger.critical("fork #2 failed: ({0:d}) {1}".format(


### PR DESCRIPTION
As discussed in #111 there is a problem on macOS 10.12.4 with running a subprocess from a double-forked daemon. Alfred-Workflow follows the classic recommendation for how to do this in Python so unless it is specific to how the Alfred app runs the workflow the problem may affect other python code as well.

This workaround is not predicated on the OS version. If the *immediate* exit of the parent process is essential to prevent zombie processes and other issues related to forking only once then this may introduce a regression.

The unit tests work fine in 10.12.4 so I think this may be related to how Alfred runs the workflow.