### PR TITLE
add Deepl workflow to library_workflows.tsv

### DIFF
--- a/extras/library_workflows.tsv
+++ b/extras/library_workflows.tsv
@@ -1,2 +1,3 @@
 name	url	author	author_url	description
 TodoList	https://github.com/ecmadao/Alfred-TodoList	ecmadao	https://github.com/ecmadao	A simple todo-workflow lets you add, complete or delete todo in to-do lists.
+DeepL translation workflow https://github.com/Skoda091/alfred-deepl Adam Skołuda https://github.com/Skoda091 DeepL translation worklflow for Alfred

--- a/extras/library_workflows.tsv
+++ b/extras/library_workflows.tsv
@@ -1,3 +1,3 @@
 name	url	author	author_url	description
 TodoList	https://github.com/ecmadao/Alfred-TodoList	ecmadao	https://github.com/ecmadao	A simple todo-workflow lets you add, complete or delete todo in to-do lists.
-DeepL-translation https://github.com/Skoda091/alfred-deepl Skoda091 https://github.com/Skoda091 DeepL translation worklflow for Alfred
+DeepL-translation	https://github.com/Skoda091/alfred-deepl	Skoda091	https://github.com/Skoda091	DeepL translation worklflow for Alfred.

--- a/extras/library_workflows.tsv
+++ b/extras/library_workflows.tsv
@@ -1,3 +1,3 @@
 name	url	author	author_url	description
 TodoList	https://github.com/ecmadao/Alfred-TodoList	ecmadao	https://github.com/ecmadao	A simple todo-workflow lets you add, complete or delete todo in to-do lists.
-DeepL translation workflow https://github.com/Skoda091/alfred-deepl Adam Skołuda https://github.com/Skoda091 DeepL translation worklflow for Alfred
+DeepL-translation https://github.com/Skoda091/alfred-deepl Skoda091 https://github.com/Skoda091 DeepL translation worklflow for Alfred


### PR DESCRIPTION
I am the author of [DeepL workflow](https://github.com/Skoda091/alfred-deepl) and I used the alfred-workflow library to develop the above mentioned Alfred workflow. Despite the fact that my workflow was published on [packal.org](http://www.packal.org), the list of workflow libraries in the README wasn't automatically updated. I have added this manually to library_workflows.tsv. 