### PR TITLE
Resolve variables from os.getenv as fallback

### DIFF
--- a/tests/test_workflow3.py
+++ b/tests/test_workflow3.py
@@ -140,6 +140,16 @@ def test_arg_variables(info3):
     assert o['variables']['key1'] == 'value1'
 
 
+def test_arg_variables_using_kwards(info3):
+    """Item3: Variables via kwardsarg."""
+    wf = Workflow3()
+    it = wf.add_item('Title', key1='value')
+    o = it.obj
+    assert 'variables' in o
+    assert 'config' not in o
+    assert o['variables']['key1'] == 'value'
+
+
 def test_feedback_variables(info3):
     """Workflow3: feedback variables."""
     wf = Workflow3()
@@ -147,14 +157,27 @@ def test_feedback_variables(info3):
     o = wf.obj
     assert 'variables' not in o
 
+    os.environ['envvar'] = 'envval'
+    os.environ['shadowed_envvar'] = 'shadowed'
+    wf.setvar('shadowed_envvar', None)
     wf.setvar('prevar', 'preval')
-    it = wf.add_item('Title', arg='something')
+    os.environ['prevar'] = 'ignored'
+    it = wf.add_item('Title', arg='something', itemvar='item1val')
+    it2 = wf.add_item('Title2', arg='something2', itemvar='item2val')
     wf.setvar('postvar', 'postval')
 
     assert wf.getvar('prevar') == 'preval'
     assert wf.getvar('postvar') == 'postval'
     assert it.getvar('prevar') == 'preval'
     assert it.getvar('postvar') is None
+
+    assert wf.getvar('envvar') == 'envval'
+    assert it.getvar('envvar') is None
+    assert it2.getvar('envvar') is None
+    assert wf.getvar('shadowed_envvar') is None
+    assert it.getvar('itemvar') == 'item1val'
+    assert it2.getvar('itemvar') == 'item2val'
+    assert wf.getvar('itemvar') is None
 
     o = wf.obj
     assert 'variables' in o

--- a/workflow/workflow3.py
+++ b/workflow/workflow3.py
@@ -556,11 +556,11 @@ class Workflow3(Workflow):
             unicode or ``default``: Value of variable if set or ``default``.
 
         """
-        return self.variables.get(name, default)
+        return self.variables.get(name, os.getenv(name, default))
 
     def add_item(self, title, subtitle='', arg=None, autocomplete=None,
                  valid=False, uid=None, icon=None, icontype=None, type=None,
-                 largetext=None, copytext=None, quicklookurl=None, match=None):
+                 largetext=None, copytext=None, quicklookurl=None, match=None, **kwargs):
         """Add an item to be output to Alfred.
 
         Args:
@@ -585,6 +585,11 @@ class Workflow3(Workflow):
 
         # Add variables to child item
         item.variables.update(self.variables)
+
+        # Copy any extra variables for this item.  These variables are set by Alfred and can
+        # be accessed in downstream actions by using {var:varname}
+        for key, value in kwargs.iteritems():
+            item.setvar(key, value)
 
         self._items.append(item)
         return item


### PR DESCRIPTION
Two changes:

1) Workflow3 instances will fallback to os.getenv if a variable value doesnt exist in the dict
2) The add_item method supports kwargs for passing item-specific configuration

Added test assertions and verified that all tests are passing.