### PR TITLE
Update README to clarify root workflow directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ Installation
 <a name="with-pip"></a>
 ### With pip ###
 
-You can install Alfred-Workflow directly into your workflow with:
+First, create a new blank workflow in Alfred (or choose an existing one if you wish). To navigate to your workflow directory in Terminal, right-click on your workflow and [click "Open in Terminal"](https://preview.ibb.co/guygvo/Screen_Shot_2018_05_25_at_11_18_35_AM.png).
 
+You can install Alfred-Workflow directly into your workflow with:
 ```bash
-# from your workflow directory
+# from your [workflow directory](https://preview.ibb.co/guygvo/Screen_Shot_2018_05_25_at_11_18_35_AM.png)
 pip install --target=. Alfred-Workflow
 ```
 
@@ -95,7 +96,7 @@ It is highly advisable to bundle all your workflow's dependencies with your work
 ### From source ###
 
 1. Download the `alfred-workflow-X.X.X.zip` from the [GitHub releases page][releases].
-2. Extract the ZIP archive and place the `workflow` directory in the root folder of your workflow (where `info.plist` is).
+2. Extract the ZIP archive and place the `workflow` directory in the [root folder of your workflow](https://image.ibb.co/iQiWvo/Screen_Shot_2018_05_25_at_11_16_50_AM.png) (where `info.plist` is).
 
 Your workflow should look something like this:
 


### PR DESCRIPTION
I'd like to propose a couple of minor tweaks to help newer folks who may not intuitively know how to navigate to the root workflow folder.