### PR TITLE
docs: fix simple typo, unchanced -> unchanged

### DIFF
--- a/workflow/util.py
+++ b/workflow/util.py
@@ -125,7 +125,7 @@ def utf8ify(s):
 
     .. versionadded:: 1.31
 
-    Returns `str` objects unchanced, encodes `unicode` objects to
+    Returns `str` objects unchanged, encodes `unicode` objects to
     UTF-8, and calls :func:`str` on anything else.
 
     Args:


### PR DESCRIPTION
There is a small typo in workflow/util.py.

Should read `unchanged` rather than `unchanced`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md