### PR TITLE
Add note to third-party guide re: ModuleNotFoundError

### DIFF
--- a/docs/guide/third-party.rst
+++ b/docs/guide/third-party.rst
@@ -75,3 +75,9 @@ instead of simply:
 
     import requests
 
+If you encounter a `ModuleNotFoundError` error, e.g. due to sub-dependencies not being aware of the `./lib` path, you can add it like this:
+
+.. code-block:: python
+
+    sys.path.append("lib")
+    from lib import requests


### PR DESCRIPTION
This thread was helpful while debugging this:

https://stackoverflow.com/questions/68345992/python3-module-import-confusion

Thank you for your extensive Alfred projects and helpful documentation, @deanishe!